### PR TITLE
Fixes port issue in CentOS

### DIFF
--- a/throttler/tc.go
+++ b/throttler/tc.go
@@ -181,6 +181,18 @@ func addIptablesRulesForAddrs(cfg *Config, c commander, command string, addrs []
 		rules = []string{addTargetCmd}
 	}
 
+	if len(addrs) == 0 && len(cfg.TargetPorts) > 0 {
+		iprules := []string{}
+		if len(rules) > 0 {
+			for _, rule := range rules {
+				iprules = append(iprules, rule)
+			}
+		}
+		if len(iprules) > 0 {
+			rules = iprules
+		}
+	}
+
 	if len(addrs) > 0 {
 		iprules := []string{}
 		for _, ip := range addrs {


### PR DESCRIPTION
Fixes issue where when adding only a port and not an ip address the port wouldn't applied to the iptable rules.